### PR TITLE
Install the plugin with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ alternate syntax for internal links, removing the need to add the `.md` suffix f
 
 Install the plugin with pip.
 ``` bash
-pip install https://github.com/cmitu/mkdocs-altlink-plugin
+pip install git+https://github.com/cmitu/mkdocs-altlink-plugin/
 ```
 
 Enable the plugin in your `mkdocs.yml`:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ alternate syntax for internal links, removing the need to add the `.md` suffix f
  
 ## Quick start
 
-Download this repo and (eventually) unzip it in a folder, or simply clone it via `git`:
+Install the plugin with pip.
 ``` bash
-git clone https://github.com/cmitu/mkdocs-altlink-plugin
+pip install https://github.com/cmitu/mkdocs-altlink-plugin
 ```
 
 Enable the plugin in your `mkdocs.yml`:


### PR DESCRIPTION
It installs from a local drive but I don't understand why it doesn't install from GitHub:

```
>pip install https://github.com/cmitu/mkdocs-altlink-plugin
Collecting https://github.com/cmitu/mkdocs-altlink-plugin
  Downloading https://github.com/cmitu/mkdocs-altlink-plugin
     \ 116 kB 6.4 MB/s
  ERROR: Cannot unpack file E:\Temp\pip-unpack-ift1td6d\mkdocs-altlink-plugin (downloaded from E:\Temp\pip-req-build-k4iqgmju, content-type: text/html; charset=utf-8); cannot detect archive format
ERROR: Cannot determine archive format of E:\Temp\pip-req-build-k4iqgmju
```