### PR TITLE
Add support for relative path for linked resources

### DIFF
--- a/mkdocs_altlink_plugin/plugin.py
+++ b/mkdocs_altlink_plugin/plugin.py
@@ -26,8 +26,11 @@ class AlternateLinkPlugin(BasePlugin):
     def _should_ignore_link(self, link):
         return link.startswith(u"http") or link.startswith(u"#") or link.startswith(u"ftp") or link.startswith(u"www") or link.startswith(u"mailto") or link.endswith(u".md")
 
-    def _is_valid_file(self, path, root):
-        return os.path.exists(path) or os.path.exists(root + "/" + path)
+    def _is_valid_file(self, path, page_path, root):
+        for p in [path, os.path.join(root, page_path, path), os.path.join(root, path)]:
+            if os.path.exists(p):
+                return True
+        return False
 
     def on_page_markdown(self, markdown, page = None, config = None, **kwargs):
 
@@ -61,7 +64,7 @@ class AlternateLinkPlugin(BasePlugin):
                 continue
 
             # Check if the link is not a resource linked (img/pdf/etc)
-            if self._is_valid_file(vals[0], doc_dir):
+            if self._is_valid_file(vals[0], os.path.dirname(page.file.src_path), doc_dir):
                 continue
 
             # Append .md to the page name, this is an internal link candidate

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mkdocs-altlink-plugin',
-    version='1.0.1',
+    version='1.0.2',
     packages=['mkdocs_altlink_plugin'],
     url='https://github.com/cmitu/mkdocs-altlink-plugin',
     license='MIT',


### PR DESCRIPTION
Relative path local to the page were not handled properly 

```
[foo][./images/foo.png]
```
would result in 
```
[foo][./images/foo.png.md]
```
and generate an error 
